### PR TITLE
feat: add `/postgres/live` endpoint for only syncing live queries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,6 +69,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Attest
         uses: actions/attest-build-provenance@v2
+        if: ${{ github.event_name == 'push' }}
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/src/server/sync.dto.ts
+++ b/src/server/sync.dto.ts
@@ -1,6 +1,12 @@
 import { z } from "zod/v4";
 import { Connectable } from "../sync/connectable.ts";
 
+export const LiveQueryRequest = z.object({
+  db: z.string().transform(Connectable.transform),
+});
+
+export type LiveQueryRequest = z.infer<typeof LiveQueryRequest>;
+
 export const SyncRequest = z.object({
   db: z.string().transform(Connectable.transform),
   seed: z.coerce.number().min(0).max(1).default(0),

--- a/src/sync/pg-connector.ts
+++ b/src/sync/pg-connector.ts
@@ -436,9 +436,8 @@ ORDER BY
       JOIN pg_user ON pg_user.usesysid = pg_stat_statements.userid
       WHERE query not like '%pg_stat_statements%'
         and query not like '%@qd_introspection%'
-        and pg_user.usename not in (/* supabase */ 'supabase_admin', 'supabase_auth_admin', /* neon */ 'cloud_admin')
-      LIMIT 10; -- @qd_introspection
-    `; // we're excluding `pg_stat_statements` from the results since it's almost certainly unrelated
+        and pg_user.usename not in (/* supabase */ 'supabase_admin', 'supabase_auth_admin', /* neon */ 'cloud_admin'); -- @qd_introspection
+      `; // we're excluding `pg_stat_statements` from the results since it's almost certainly unrelated
       return {
         kind: "ok",
         queries: results,


### PR DESCRIPTION
Allows implementing the live query update feature on IXR. This will be followed up and the query slightly tweaked to use a cursor instead that pulls 5-10 queries at a time to parse and potentially discard at the application layer to avoid the problem of having too few valid queries when the invalid stuff gets filtered out