### PR TITLE
feat: implement basic first seen cache

### DIFF
--- a/src/query-cache.ts
+++ b/src/query-cache.ts
@@ -1,0 +1,63 @@
+import crypto from "node:crypto";
+import { RawRecentQuery, RecentQuery } from "./sync/pg-connector.ts";
+
+interface CacheEntry {
+  firstSeen: number;
+  lastSeen: number;
+}
+
+export class QueryCache {
+  list: Record<string, CacheEntry> = {};
+  private readonly createdAt: number;
+
+  constructor() {
+    this.createdAt = Date.now();
+  }
+
+  isCached(key: string): boolean {
+    const entry = this.list[key];
+    if (!entry) {
+      return false;
+    }
+    return true;
+  }
+
+  isNew(key: string): boolean {
+    const entry = this.list[key];
+    if (!entry) {
+      return true;
+    }
+    return entry.firstSeen >= this.createdAt;
+  }
+
+  store(db: string, query: string) {
+    const key = hash(db, query);
+    const now = Date.now();
+    if (this.list[key]) {
+      this.list[key].lastSeen = now;
+    } else {
+      this.list[key] = { firstSeen: now, lastSeen: now };
+    }
+    return key;
+  }
+
+  getFirstSeen(key: string): number {
+    return this.list[key]?.firstSeen || Date.now();
+  }
+
+  sync(db: string, queries: RawRecentQuery[]): RecentQuery[] {
+    return queries.map(query => {
+      const key = this.store(db, query.query);
+      return {
+        ...query,
+        firstSeen: this.getFirstSeen(key)
+      };
+    });
+  }
+}
+
+export const queryCache = new QueryCache();
+
+function hash(db: string, query: string): string {
+  return crypto.createHash("sha256").update(JSON.stringify([db, query])).digest("hex")
+}

--- a/src/sync/pg-connector.ts
+++ b/src/sync/pg-connector.ts
@@ -51,13 +51,17 @@ export type SerializeResult = {
   sampledRecords: Record<TableName, number>;
 };
 
-export type RecentQuery = {
+export type RawRecentQuery = {
   username: string;
   query: string;
   meanTime: number;
   calls: string;
   rows: string;
   topLevel: boolean;
+};
+
+export type RecentQuery = RawRecentQuery & {
+  firstSeen: number;
 };
 
 export type RecentQueriesError =
@@ -75,7 +79,7 @@ export type RecentQueriesError =
 export type RecentQueriesResult =
   | {
       kind: "ok";
-      queries: RecentQuery[];
+      queries: RawRecentQuery[];
     }
   | RecentQueriesError;
 
@@ -449,7 +453,7 @@ ORDER BY
 
   public async getRecentQueries(): Promise<RecentQueriesResult> {
     try {
-      const results = await this.sql<RecentQuery[]>`
+      const results = await this.sql<RawRecentQuery[]>`
       SELECT
         pg_user.usename as "username",
         query,


### PR DESCRIPTION
This add `firstSeen` to the list of queries with a "local" cache that's ephemeral to the instance. Silly first implementation but good to get the ball rolling on the feature.